### PR TITLE
remove now unused class

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,0 @@
-class htop::install {
-  if !defined(Package[$htop::params::package_name]) {
-    package { $htop::params::package_name:
-      ensure => present,
-    }
-  }
-}


### PR DESCRIPTION
htop::install's functionality has been moved into htop
remove this file, which should've been done in the previous commit.
